### PR TITLE
feat: add wallet creation and import options

### DIFF
--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -1,0 +1,17 @@
+import { Wallet } from 'ethers';
+
+export interface WalletInfo {
+  mnemonic: string;
+  address: string;
+}
+
+export function createWallet(): WalletInfo {
+  const wallet = Wallet.createRandom();
+  const mnemonic = wallet.mnemonic?.phrase || '';
+  return { mnemonic, address: wallet.address };
+}
+
+export function importWallet(mnemonic: string): WalletInfo {
+  const wallet = Wallet.fromPhrase(mnemonic.trim());
+  return { mnemonic: wallet.mnemonic?.phrase || '', address: wallet.address };
+}


### PR DESCRIPTION
## Summary
- add core wallet helpers to generate and import mnemonic wallets
- update popup to show create or import wallet options and display mnemonic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896ba3d32e4832ca54bcf6fa29c1090