### PR TITLE
feat: add password-protected wallet login

### DIFF
--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -15,3 +15,13 @@ export function importWallet(mnemonic: string): WalletInfo {
   const wallet = Wallet.fromPhrase(mnemonic.trim());
   return { mnemonic: wallet.mnemonic?.phrase || '', address: wallet.address };
 }
+
+export async function encryptWallet(mnemonic: string, password: string): Promise<string> {
+  const wallet = Wallet.fromPhrase(mnemonic.trim());
+  return wallet.encrypt(password);
+}
+
+export async function decryptWallet(encryptedJson: string, password: string): Promise<WalletInfo> {
+  const wallet = await Wallet.fromEncryptedJson(encryptedJson, password);
+  return { mnemonic: wallet.mnemonic?.phrase || '', address: wallet.address };
+}


### PR DESCRIPTION
## Summary
- add encrypt/decrypt helpers for wallet mnemonic
- add password setup and unlock views to extension popup

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896c463bf34832c8299ebfcd34cc65c