### PR TITLE
fix transaction status handling

### DIFF
--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -67,7 +67,10 @@ export async function sendEth(
   const wallet = Wallet.fromPhrase(mnemonic.trim()).connect(provider);
   const tx = await wallet.sendTransaction({ to, value: parseEther(amountEth) });
   const receipt = await tx.wait();
-  return { hash: receipt.hash, status: receipt.status ?? 0 };
+  // Ethers may return the status as a bigint or null, so normalize to a
+  // simple number (1 for success, 0 for failure) for easier checks in the UI.
+  const status = Number(receipt.status ?? 0);
+  return { hash: receipt.hash, status };
 }
 
 export async function getTransactionHistory(

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -183,7 +183,8 @@ const Popup: React.FC = () => {
     try {
       setSending(true);
       const { hash, status } = await sendEth(walletInfo.mnemonic, toAddress, amount, network);
-      alert(status === 1 ? `Transaction successful: ${hash}` : `Transaction failed: ${hash}`);
+      const success = Number(status) === 1;
+      alert(success ? `Transaction successful: ${hash}` : `Transaction failed: ${hash}`);
       const newBalance = await getEthBalance(walletInfo.address, network);
       setBalance(parseFloat(newBalance).toFixed(4));
       const txHistory = await getTransactionHistory(walletInfo.address, network);


### PR DESCRIPTION
## Summary
- normalize transaction receipt status to numbers in wallet send logic
- ensure popup checks numeric status before showing success message

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689702be4e40832cad066a67c7a3ed9b