### PR TITLE
feat: add language toggle for titles and buttons

### DIFF
--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -1,0 +1,41 @@
+export const translations = {
+  en: {
+    title: 'LuckYou Wallet',
+    network: 'Network:',
+    createWallet: 'Create Wallet',
+    importWallet: 'Import Wallet',
+    import: 'Import',
+    cancel: 'Cancel',
+    save: 'Save',
+    unlock: 'Unlock',
+    clearWallet: 'Clear Wallet',
+    sendETH: 'Send ETH',
+    activity: 'Activity',
+    logout: 'Logout',
+    send: 'Send',
+    sending: 'Sending...',
+    back: 'Back',
+    noTransactions: 'No sent transactions',
+  },
+  zh: {
+    title: 'LuckYou 钱包',
+    network: '网络:',
+    createWallet: '创建钱包',
+    importWallet: '导入钱包',
+    import: '导入',
+    cancel: '取消',
+    save: '保存',
+    unlock: '解锁',
+    clearWallet: '清除钱包',
+    sendETH: '发送 ETH',
+    activity: '交易记录',
+    logout: '退出',
+    send: '发送',
+    sending: '发送中...',
+    back: '返回',
+    noTransactions: '无发送交易',
+  },
+} as const;
+
+export type Lang = keyof typeof translations;
+export type TranslationKey = keyof typeof translations['en'];

--- a/src/popup/Activity.tsx
+++ b/src/popup/Activity.tsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import { TransactionRecord, WalletInfo } from '../core/wallet';
+import { TranslationKey } from '../core/i18n';
 
 interface ActivityProps {
   records: TransactionRecord[];
   wallet: WalletInfo;
   onBack: () => void;
+  t: (key: TranslationKey) => string;
 }
 
-const Activity: React.FC<ActivityProps> = ({ records, wallet, onBack }) => {
+const Activity: React.FC<ActivityProps> = ({ records, wallet, onBack, t }) => {
   const address = wallet.address.toLowerCase();
   const sent = records.filter((r) => r.from.toLowerCase() === address);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-      <button onClick={onBack}>Back</button>
-      <h3>Activity</h3>
+      <button onClick={onBack}>{t('back')}</button>
+      <h3>{t('activity')}</h3>
       {sent.length === 0 ? (
-        <p>No sent transactions</p>
+        <p>{t('noTransactions')}</p>
       ) : (
         <ul style={{ maxHeight: '150px', overflowY: 'auto', paddingLeft: '1rem' }}>
           {sent.map((r) => (


### PR DESCRIPTION
## Summary
- enable Chinese/English translations via new i18n module
- add language selector and apply translations to popup titles and buttons
- wire activity view to shared translations

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689704c86f5c832cb119e15b7039190f