### PR TITLE
Fix transaction history retrieval

### DIFF
--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -84,7 +84,9 @@ export async function getTransactionHistory(
   for (let i = latest; i >= start; i--) {
     const block = await provider.getBlock(i, true);
     if (!block) continue;
-    for (const tx of block.transactions) {
+    for (const txHash of block.transactions) {
+      const tx = await provider.getTransaction(txHash);
+      if (!tx) continue;
       const from = tx.from.toLowerCase();
       const toAddr = (tx.to || '').toLowerCase();
       const target = address.toLowerCase();


### PR DESCRIPTION
## Summary
- Ensure transaction history scans pull full transaction details before filtering

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897071566c4832c9eda59eeeeaf7151