### PR TITLE
Display balances with five decimal places

### DIFF
--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -110,7 +110,7 @@ export async function getTransactionHistory(
           hash: tx.hash,
           from: tx.from,
           to: tx.to || '',
-          value: formatEther(tx.value),
+          value: parseFloat(formatEther(tx.value)).toFixed(5),
           status,
         });
       }

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -207,7 +207,7 @@ const Popup: React.FC = () => {
         hash,
         from: walletInfo.address,
         to: toAddress,
-        value: amount,
+        value: parseFloat(amount).toFixed(5),
         status: Number(status),
       };
       const key = getHistoryKey(walletInfo.address, network);
@@ -217,7 +217,7 @@ const Popup: React.FC = () => {
         return updated;
       });
       const newBalance = await getEthBalance(walletInfo.address, network);
-      setBalance(parseFloat(newBalance).toFixed(4));
+      setBalance(parseFloat(newBalance).toFixed(5));
       const txHistory = await getTransactionHistory(walletInfo.address, network);
       setHistory(txHistory);
       localStorage.setItem(key, JSON.stringify(txHistory));
@@ -265,7 +265,7 @@ const Popup: React.FC = () => {
         setHistory([]);
       }
       getEthBalance(walletInfo.address, network)
-        .then((b) => setBalance(parseFloat(b).toFixed(4)))
+        .then((b) => setBalance(parseFloat(b).toFixed(5)))
         .catch((e) => {
           console.error('Failed to fetch balance', e);
           setBalance('');


### PR DESCRIPTION
## Summary
- Show transaction amounts with five decimal places
- Maintain wallet balance values to five decimals
- Normalize fetched transaction history values to five decimals

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689866e273ec832cabd1c9136f764d90