### PR TITLE
feat: add custom token support

### DIFF
--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -25,6 +25,10 @@ export const translations = {
     viewOnEtherscan: 'View on Etherscan',
     success: 'Success',
     fail: 'Fail',
+    tokens: 'Tokens:',
+    addToken: 'Add Token',
+    tokenAddress: 'Token Contract Address',
+    add: 'Add',
   },
   zh: {
     title: 'LuckYou 钱包',
@@ -52,6 +56,10 @@ export const translations = {
     viewOnEtherscan: '在 Etherscan 查看',
     success: '成功',
     fail: '失败',
+    tokens: '代币:',
+    addToken: '添加代币',
+    tokenAddress: '代币合约地址',
+    add: '添加',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- add ERC-20 token utilities for fetching metadata and balances
- allow popup to add custom tokens per network and show token balances
- add translations for token management

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aec6a835c832ca49078b3cfe07735